### PR TITLE
Respect .gitignore in TreeView for optimized file handling

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -28,6 +28,9 @@
             <li>Level-specific operations - apply actions only to the current level</li>
           </ul>
         </li>
+        <li>
+            Improved performance by unchecking files/folders mentioned in .gitignore by default in the TreeView.
+        </li>
       </ul>
     ]]></change-notes>
 


### PR DESCRIPTION
## Description

Enhanced the TreeView to respect `.gitignore` files for improved performance and usability. Files and folders specified in `.gitignore` are now unchecked by default during tree construction. Implemented functionality to parse and apply `.gitignore` patterns and added respective tests to ensure reliability.

---

## Checklist

- [x] My code follows the [JetTreeMark Contribution Guidelines](./CONTRIBUTING.md).
- [x] I have tested the changes locally.
- [x] I have added or updated necessary documentation (if applicable).
- [x] I have updated the changelog (if applicable).
- [x] I have ensured that my changes do not break existing features.